### PR TITLE
Fixing query for returning both task and challenges

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -369,6 +369,7 @@ async function searchChallenges (currentUser, criteria) {
     mustQuery.push({
       bool: {
         should: [
+          { bool: { must_not: { exists: { field: 'task.isTask' } } } },
           { match_phrase: { 'task.isTask': false } },
           {
             bool: {


### PR DESCRIPTION
Seems like `task.isTask : false` is not enough for the cases where task json is null or task.isTask does not exist.