### PR TITLE
Should read from payload

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1425,11 +1425,11 @@ async function update (currentUser, challengeId, data, userToken, isFull) {
   const { track, type } = await validateChallengeData(_.pick(challenge, ['trackId', 'typeId']))
 
   if (_.get(type, 'isTask')) {
-    if (!_.isEmpty(_.get(challenge, 'task.memberId'))) {
+    if (!_.isEmpty(_.get(data, 'task.memberId'))) {
       const challengeResources = await helper.getChallengeResources(challengeId)
       const registrants = _.filter(challengeResources, r => r.roleId === config.SUBMITTER_ROLE_ID)
-      if (!_.find(registrants, r => _.toString(r.memberId) === _.toString(_.get(challenge, 'task.memberId')))) {
-        throw new errors.BadRequestError(`Member ${_.get(challenge, 'task.memberId')} is not a submitter resource of challenge ${challengeId}`)
+      if (!_.find(registrants, r => _.toString(r.memberId) === _.toString(_.get(data, 'task.memberId')))) {
+        throw new errors.BadRequestError(`Member ${_.get(data, 'task.memberId')} is not a submitter resource of challenge ${challengeId}`)
       }
     }
   }


### PR DESCRIPTION
Should read `task.memberId` from payload instead of the existing challenge value as reading it from existing values is preventing us from changing the assigned member.