### PR TITLE
fix: enable ecs-containers-readonly-access and update docker cmd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ install_dependency: &install_dependency
 install_deploysuite: &install_deploysuite
   name: Installation of install_deploysuite.
   command: |
-    git clone --branch v1.4.14 https://github.com/topcoder-platform/tc-deploy-scripts ../buildscript
+    git clone --branch v1.4.15 https://github.com/topcoder-platform/tc-deploy-scripts ../buildscript
     cp ./../buildscript/master_deploy.sh .
     cp ./../buildscript/buildenv.sh .
     cp ./../buildscript/awsconfiguration.sh .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /challenge-api
 # Install the dependencies from package.json
 RUN yarn install
 
-CMD yarn start
+CMD node /challenge-api/app.js


### PR DESCRIPTION
- Update tc-deploy-scripts to v1.4.15 to set environment variables for enabling ecs-containers-readonly-access
- Modify Dockerfile to replace 'yarn start' with 'node /challenge-api/app.js' to ensure compatibility with read-only file systems

Enabling ecs-containers-readonly-access ensures that the container file system is read-only, reducing the risk of unauthorized modifications to the application files during runtime. Replacing 'yarn start' with 'node /challenge-api/app.js' addresses potential issues with Yarn requiring a writable file system for certain operations, ensuring a smooth deployment on a read-only environment.