### PR TITLE
PLAT-3453 Stop copilots from paying themselves

### DIFF
--- a/src/common/challenge-helper.js
+++ b/src/common/challenge-helper.js
@@ -105,9 +105,9 @@ class ChallengeHelper {
     }
   }
 
-  async validateChallengeUpdateRequest(currentUser, challenge, data) {
+  async validateChallengeUpdateRequest(currentUser, challenge, data, challengeResources) {
     if (process.env.LOCAL != "true") {
-      await helper.ensureUserCanModifyChallenge(currentUser, challenge);
+      await helper.ensureUserCanModifyChallenge(currentUser, challenge, challengeResources);
     }
 
     helper.ensureNoDuplicateOrNullElements(data.tags, "tags");

--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -528,14 +528,17 @@ async function getResourceRoles() {
  * Check if a user has full access on a challenge
  * @param {String} challengeId the challenge UUID
  * @param {String} userId the user ID
+ * @param {Array} challengeResources the challenge resources
  */
-async function userHasFullAccess(challengeId, userId) {
+async function userHasFullAccess(challengeId, userId, challengeResources) {
   const resourceRoles = await getResourceRoles();
   const rolesWithFullAccess = _.map(
     _.filter(resourceRoles, (r) => r.fullWriteAccess),
     "id"
   );
-  const challengeResources = await getChallengeResources(challengeId);
+  if (!challengeResources) {
+    challengeResources = await getChallengeResources(challengeId);
+  }
   return (
     _.filter(
       challengeResources,
@@ -982,13 +985,14 @@ async function ensureUserCanViewChallenge(currentUser, challenge) {
  *
  * @param {Object} currentUser the user who perform operation
  * @param {Object} challenge the challenge to check
+ * @param {Array} challengeResources the challenge resources
  * @returns {Promise}
  */
-async function ensureUserCanModifyChallenge(currentUser, challenge) {
+async function ensureUserCanModifyChallenge(currentUser, challenge, challengeResources) {
   // check groups authorization
   await ensureAccessibleByGroupsAccess(currentUser, challenge);
   // check full access
-  const isUserHasFullAccess = await userHasFullAccess(challenge.id, currentUser.userId);
+  const isUserHasFullAccess = await userHasFullAccess(challenge.id, currentUser.userId, challengeResources);
   if (
     !currentUser.isMachine &&
     !hasAdminRole(currentUser) &&


### PR DESCRIPTION
1. Stop copilots from paying themselves, thus copilots will need to contact manager to launch/complete the task
2. When updateChallenge, the helper.getChallengeResources function is called multiple times, now it's called only once