### PR TITLE
HOTFIX - Fix registrants tab for MM 153 / challenge ID f472598c-9022-444a-be87-66c3af4b7fae

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -1353,12 +1353,6 @@ getChallenge.schema = {
  */
 async function getChallengeStatistics(currentUser, id) {
   const challenge = await getChallenge(currentUser, id);
-  // for now, only Data Science challenges are supported
-  if (challenge.type !== "Challenge" && challenge.track !== "Data Science") {
-    throw new errors.BadRequestError(
-      `Challenge of type ${challenge.type} and track ${challenge.track} does not support statistics`
-    );
-  }
   // get submissions
   const submissions = await helper.getChallengeSubmissions(challenge.id);
   // for each submission, load member profile


### PR DESCRIPTION
Remove a check on the statistics endpoint limiting them to Data Science track only.  The current MM was launched under the Development track and the Registrants tab isn't working.