### PR TITLE
Tweak the check here to match Phoenix requirements for billing accounts

### DIFF
--- a/src/services/ChallengeService.js
+++ b/src/services/ChallengeService.js
@@ -884,7 +884,7 @@ async function createChallenge(currentUser, challenge, userToken) {
   }
 
   /** Ensure project exists, and set direct project id, billing account id & markup */
-  if (challengeHelper.isProjectIdRequired(challenge.timelineTemplateId)) {
+  if (challengeHelper.isProjectIdRequired(challenge.timelineTemplateId) || challenge.projectId) {
     const { projectId } = challenge;
 
     const { directProjectId } = await projectHelper.getProject(projectId, currentUser);


### PR DESCRIPTION
 Here’s what I did:

1. If you do not pass in a project ID when creating a challenge, but you do pass in the Phoenix timeline template ID (517e76b0-8824-4e72-9b48-a1ebde1793a8), the system will do no checking of any billing accounts.  This is the current flow for you
3. After this change, if you do pass in a project ID, the budget check will happen, regardless of the timeline template ID.   The goal here is that all you need to do is add the project ID and make no other changes.

If you pass in a project ID and prizes that exceed the budget, you’ll get an error like this:

```
{
    "code": 13,
    "message": "Budget Error: Requested amount $256000000 exceeds available budget for Billing Account #80001072. Please contact the Topcoder Project Manager for further assistance."
}
```